### PR TITLE
added geopackage dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
 			<artifactId>gt-geojson</artifactId>
 			<version>${geotools.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-geopkg</artifactId>
+			<version>${geotools.version}</version>
+		</dependency>
 		
 	</dependencies>
 


### PR DESCRIPTION
Added to the pom.xml a dependency to enable the tracing engine to use Geopackage as a data store. This has been successfully used for the [GO-PEG ](https://github.com/gopeg) 'Tracing Use-case', developed by the SADL (Spatial Applications Division) team at KU Leuven.